### PR TITLE
Disable remotesensors for players

### DIFF
--- a/src/FP_ComfyDowntime.VR/init.sqf
+++ b/src/FP_ComfyDowntime.VR/init.sqf
@@ -3,5 +3,5 @@ enableCamShake true;
 setViewDistance 2000;
 setObjectViewDistance 1800;
 setTerrainGrid 25;
-disableRemoteSensors false;
+
 [] execVM "scripts\fn_advancedSlingLoadingInit.sqf"

--- a/src/FP_ComfyDowntime.VR/initPlayerLocal.sqf
+++ b/src/FP_ComfyDowntime.VR/initPlayerLocal.sqf
@@ -16,3 +16,12 @@ player addEventHandler ["Respawn", {
   // Set Custom Fatigue Settings
   player setCustomAimCoef 0.6;
 }];
+
+[{
+    if (hasInterface &&
+        {!isServer} &&
+        {isNull (getAssignedCuratorLogic player)}
+    ) then {
+        disableRemoteSensors true;
+    };
+}, [], 1] call ACE_common_fnc_waitAndExecute;


### PR DESCRIPTION
Disable remote sensors for regular clients (not server, hc, zeus)
Curator logic might be null at time 0
