### PR TITLE
fixes #2 Paradrop check distance for enemies

### DIFF
--- a/src/FP_ComfyDowntime.VR/base/functions/custom/fn_paradrop.sqf
+++ b/src/FP_ComfyDowntime.VR/base/functions/custom/fn_paradrop.sqf
@@ -3,8 +3,8 @@ _param_distance = ["ParadropMaxDistEnemy"] call BIS_fnc_getParamValue;
 
 _exit = false;
 if (_param_distance > 0) then {
-  _units = allUnits select {!(side _x in [side group player, civilian])};
-  _close = _units select {(_x distance _pos) < _param_distance};
+  _units = allUnits select {alive _x && {!((side _x) in [side group player, civilian])}};
+  _close = _units select {((getPosATL _x) select 2) < 10 && {(_x distance _pos) < _param_distance}};
   _exit = count _close > 0;
 };
 

--- a/src/FP_ComfyDowntime.VR/base/functions/custom/fn_paradrop.sqf
+++ b/src/FP_ComfyDowntime.VR/base/functions/custom/fn_paradrop.sqf
@@ -1,4 +1,17 @@
 params ["_pos"];
+_param_distance = ["ParadropMaxDistEnemy"] call BIS_fnc_getParamValue;
+
+_exit = false;
+if (_param_distance > 0) then {
+  _units = allUnits select {!(side _x in [side group player, civilian])};
+  _close = _units select {(_x distance _pos) < _param_distance};
+  _exit = count _close > 0;
+};
+
+if (_exit) exitWith {
+  hintC format ["Cannot paradrop with enemies within %1m", _param_distance];
+};
+
 player setPos [_pos select 0, _pos select 1, (_pos select 2) + 600];
 
 // Get Loadout the player currently has

--- a/src/FP_ComfyDowntime.VR/base/functions/custom/fn_paradrop.sqf
+++ b/src/FP_ComfyDowntime.VR/base/functions/custom/fn_paradrop.sqf
@@ -1,4 +1,5 @@
-hintC "Select Altitude and Designate LZ for HALO Jump on the map";
+params ["_pos"];
+player setPos [_pos select 0, _pos select 1, (_pos select 2) + 600];
 
 // Get Loadout the player currently has
 _backpack_type = backpack player;
@@ -13,17 +14,9 @@ removeHeadgear player;
 player addBackpack "B_Parachute";
 player addHeadgear "H_CrewHelmetHeli_B";
 
-// Open the map and let the Person click where he wants to land
-openMap true;
-onMapSingleClick {
-  player setPos [_pos select 0, _pos select 1, (_pos select 2) + 600];
-  openMap [false, false];
-  onMapSingleClick {};
-};
-
-waitUntil { not visibleMap };
 sleep 5;
-waitUntil { isTouchingGround player };
+waitUntil { isTouchingGround player || !alive player};
+if (!alive player) exitWith {};
 
 // Reapply gear we had before the jump
 removeBackpack player;
@@ -31,12 +24,13 @@ removeHeadgear player;
 player addBackpack _backpack_type;
 player addHeadgear _headgear;
 
+_bp = unitBackpack player;
 if (count (_backpack_weaps select 0) > 0) then {for "_i" from 0 to (count (_backpack_weaps select 0) - 1) do {
-  (unitBackpack player) addweaponCargoGlobal [(_backpack_weaps select 0) select _i,(_backpack_weaps select 1) select _i];};
+  _bp addweaponCargoGlobal [(_backpack_weaps select 0) select _i,(_backpack_weaps select 1) select _i];};
 };
 if (count (_backpack_magas select 0) > 0) then {for "_i" from 0 to (count (_backpack_magas select 0) - 1) do {
-  (unitBackpack player) addMagazineCargoGlobal [(_backpack_magas select 0) select _i,(_backpack_magas select 1) select _i];};
+  _bp addMagazineCargoGlobal [(_backpack_magas select 0) select _i,(_backpack_magas select 1) select _i];};
 };
 if (count (_backpack_items select 0) > 0) then {for "_i" from 0 to (count (_backpack_items select 0) - 1) do {
-  (unitBackpack player) addItemCargoGlobal [(_backpack_items select 0) select _i,(_backpack_items select 1) select _i];};
+  _bp addItemCargoGlobal [(_backpack_items select 0) select _i,(_backpack_items select 1) select _i];};
 };

--- a/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
+++ b/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
@@ -10,7 +10,23 @@ _object allowDamage false;
 
 // Add ACE Actions to the Box.
 if (_param_paradrop isEqualType 1) then {
-  _action_paradrop = ["fpc_paradrop", "Start Paradrop", "", {[] spawn FPC_fnc_paradrop;}, {true}] call ace_interact_menu_fnc_createAction;
+  FPC_paradropping = false;
+  
+  ["FPC_MAP", "onMapSingleClick", {
+      if (FPC_paradropping) then {
+        [_pos] spawn FPC_fnc_paradrop;
+        FPC_paradropping = false;
+      };
+    }] call BIS_fnc_addStackedEventHandler;
+    
+  _drop_code = {
+    hintC "Select Altitude and Designate LZ for HALO Jump on the map";
+    // Open the map and let the Person click where he wants to land
+    FPC_paradropping = true;
+    openMap true;
+  };
+
+  _action_paradrop = ["fpc_paradrop", "Start Paradrop", "", _drop_code, {true}] call ace_interact_menu_fnc_createAction;
   [_object, 0, ["ACE_MainActions"], _action_paradrop] spawn ace_interact_menu_fnc_addActionToObject;
 };
 

--- a/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
+++ b/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
@@ -20,7 +20,7 @@ if (_param_paradrop isEqualTo 1) then {
     }] call BIS_fnc_addStackedEventHandler;
     
   _drop_code = {
-    hintC "Select Altitude and Designate LZ for HALO Jump on the map";
+    hintC "Select LZ for HALO Jump on the map";
     // Open the map and let the Person click where he wants to land
     FPC_paradropping = true;
     openMap true;

--- a/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
+++ b/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
@@ -16,7 +16,6 @@ if (_param_paradrop isEqualTo 1) then {
       if (FPC_paradropping) then {
         openMap [false, false];
         [_pos] spawn FPC_fnc_paradrop;
-        FPC_paradropping = false;
       };
     }] call BIS_fnc_addStackedEventHandler;
     
@@ -25,6 +24,10 @@ if (_param_paradrop isEqualTo 1) then {
     // Open the map and let the Person click where he wants to land
     FPC_paradropping = true;
     openMap true;
+    [] spawn {
+      waitUntil {!visibleMap};
+      FPC_paradropping = false;
+    };
   };
 
   _action_paradrop = ["fpc_paradrop", "Start Paradrop", "", _drop_code, {true}] call ace_interact_menu_fnc_createAction;

--- a/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
+++ b/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
@@ -14,6 +14,7 @@ if (_param_paradrop isEqualTo 1) then {
   
   ["FPC_paradrop_map", "onMapSingleClick", {
       if (FPC_paradropping) then {
+        openMap [false, false];
         [_pos] spawn FPC_fnc_paradrop;
         FPC_paradropping = false;
       };

--- a/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
+++ b/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
@@ -30,7 +30,7 @@ if (_param_paradrop isEqualTo 1) then {
   [_object, 0, ["ACE_MainActions"], _action_paradrop] spawn ace_interact_menu_fnc_addActionToObject;
 };
 
-if (_param_bandage isEqualType 1) then {
+if (_param_bandage isEqualTo 1) then {
   _action_bandage = ["fpc_bandage", "Fix yourself up", "", {
     player setDamage 0;
     player allowDamage true;
@@ -44,7 +44,7 @@ if (_param_bandage isEqualType 1) then {
   [_object, 0, ["ACE_MainActions"], _action_bandage] spawn ace_interact_menu_fnc_addActionToObject;
 };
 
-if (_param_arsenal isEqualType 1) then {
+if (_param_arsenal isEqualTo 1) then {
   ["AmmoboxInit",[_object,true]] spawn BIS_fnc_arsenal;
 };
 

--- a/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
+++ b/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
@@ -12,7 +12,7 @@ _object allowDamage false;
 if (_param_paradrop isEqualTo 1) then {
   FPC_paradropping = false;
   
-  ["FPC_MAP", "onMapSingleClick", {
+  ["FPC_paradrop_map", "onMapSingleClick", {
       if (FPC_paradropping) then {
         [_pos] spawn FPC_fnc_paradrop;
         FPC_paradropping = false;

--- a/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
+++ b/src/FP_ComfyDowntime.VR/base/functions/custom/fn_setupResupplyBox.sqf
@@ -9,7 +9,7 @@ _param_arsenal = ["ArsenalEnable"] call BIS_fnc_getParamValue;
 _object allowDamage false;
 
 // Add ACE Actions to the Box.
-if (_param_paradrop isEqualType 1) then {
+if (_param_paradrop isEqualTo 1) then {
   FPC_paradropping = false;
   
   ["FPC_MAP", "onMapSingleClick", {

--- a/src/FP_ComfyDowntime.VR/description.ext
+++ b/src/FP_ComfyDowntime.VR/description.ext
@@ -43,6 +43,12 @@ class Params {
     texts[] = {"No","Yes"};
     default = 1;
   };
+  class ParadropMaxDistEnemy {
+    title = "[Paradrop] Cannot paradrop close to enemy";
+    values[] = {0, 200, 300, 400, 600};
+    texts[] = {"Disabled","200m", "300m", "400m", "600m"};
+    default = 2;
+  };
   class FixYourselfUpEnable {
     title = "[Supply Box] Enable Fix Health";
     values[] = {0,1};

--- a/src/FP_ComfyDowntime.VR/description.ext
+++ b/src/FP_ComfyDowntime.VR/description.ext
@@ -47,7 +47,7 @@ class Params {
     title = "[Paradrop] Cannot paradrop close to enemy";
     values[] = {0, 200, 300, 400, 600};
     texts[] = {"Disabled","200m", "300m", "400m", "600m"};
-    default = 2;
+    default = 300;
   };
   class FixYourselfUpEnable {
     title = "[Supply Box] Enable Fix Health";


### PR DESCRIPTION
- Changed the onMapSingleClick to be a stacked eventhandler, there can only be one of these, now it prevents overriding any addons that rely on onMapSingleClick to work
- fnc_paradrop now takes a position, and verifies that there are no enemies close (if enabled, default = 300m)
- also changed the isEqualType to isEqualTo in setupResupplyBox.sqf, isEqualType does typechecking so whatever params was set would be ignored and always be true (since it's a number)
