### PR TITLE
Remove MenuInventory

### DIFF
--- a/src/FP_ComfyDowntime.VR/description.ext
+++ b/src/FP_ComfyDowntime.VR/description.ext
@@ -3,7 +3,7 @@ respawndelay = 5;
 respawnDialog = 0;
 respawn = 3;
 respawnOnStart = 1;
-respawnTemplates[] = {"MenuPosition", "MenuInventory"};
+respawnTemplates[] = {"MenuPosition"};
 
 #include "scripts\taw_vd\GUI.h"
 


### PR DESCRIPTION
MenuInventory template breaks loadouts because of the new respawn system. Removing it keeps loadouts intact, as well as the ability to choose your own spawn.
